### PR TITLE
Add AI Models Catalog to Other-Awesome list

### DIFF
--- a/docs/other-awesome.md
+++ b/docs/other-awesome.md
@@ -58,6 +58,7 @@
 |  49 | Awesome-OpenClaw-Skills                      | OpenClaw社区构建的技能                    | VoltAgent       | ![GitHub stars](https://img.shields.io/github/stars/VoltAgent/awesome-openclaw-skills?style=flat-square)                        | [GitHub](https://github.com/VoltAgent/awesome-openclaw-skills)                        |
 |  50 | Awesome-Claude-Code                          | Claude Code相关技能和工具                 | hesreallyhim    | ![GitHub stars](https://img.shields.io/github/stars/hesreallyhim/awesome-claude-code?style=flat-square)                         | [GitHub](https://github.com/hesreallyhim/awesome-claude-code)                         |
 |  51 | Awesome-Claude-Skills                        | Claude技能、资源和工具                     | ComposioHQ      | ![GitHub stars](https://img.shields.io/github/stars/ComposioHQ/awesome-claude-skills?style=flat-square)                         | [GitHub](https://github.com/ComposioHQ/awesome-claude-skills)                         |
+|  52 | AI-Models-Catalog                            | 95个AI提供商4587+模型的结构化目录（定价/上下文/能力） | i-need-token    | ![GitHub stars](https://img.shields.io/github/stars/i-need-token/ai-models?style=flat-square)                                   | [GitHub](https://github.com/i-need-token/ai-models)                                   |
 
 [← 返回主页](../README.md#other-awesome)
 


### PR DESCRIPTION
## 新增资源

- **名称:** AI Models Catalog
- **地址:** https://github.com/i-need-token/ai-models

## 说明

95个AI提供商、4587+模型的结构化YAML目录，包含定价、上下文窗口、模态、能力等元数据。所有数据来自一手API和官方文档。

特点：
- 覆盖95个提供商（包括阿里、百度、百川、DeepSeek、科大讯飞、MiniMax、月之暗面、智谱等中国提供商）
- 交互式目录：https://i-need-token.github.io/ai-models/
- 机器可读YAML + TypeScript类型 + Zod校验
- GitHub Action支持CI/CD集成
- 76篇双语文档（38英文 + 38中文）

## 适合加入Other-Awesome的原因

本仓库收集高质量中文预训练模型和大语言模型资源，AI Models Catalog提供了95个提供商的结构化模型数据（包括中国提供商的定价、上下文窗口、能力等），可以作为模型选择和对比的参考工具。

## Checklist
- [x] 遵循现有表格格式
- [x] 按序号添加
- [x] 描述简洁准确
- [x] 非重复条目